### PR TITLE
Initial backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+server/db/
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# thatimagetaggingsite
+# Acuity
 Image Sharing Platform, with automagically tagged images, for added searchability

--- a/server/config.js
+++ b/server/config.js
@@ -1,4 +1,4 @@
 exports.db = {
-  host: process.env.TITS_DB_URL || 'localhost'.
-  port: process.env.TITS_DB_PORT || 28015
+  host: process.env.TISS_DB_URL || 'localhost',
+  port: process.env.TISS_DB_PORT || 28015
 }

--- a/server/config.js
+++ b/server/config.js
@@ -1,4 +1,4 @@
 exports.db = {
-  host: process.env.TISS_DB_URL || 'localhost',
-  port: process.env.TISS_DB_PORT || 28015
+  host: process.env.ACUITY_DB_URL || 'localhost',
+  port: process.env.ACUITY_DB_PORT || 28015
 }

--- a/server/config.js
+++ b/server/config.js
@@ -1,4 +1,5 @@
 exports.db = {
   host: process.env.ACUITY_DB_URL || 'localhost',
-  port: process.env.ACUITY_DB_PORT || 28015
+  port: process.env.ACUITY_DB_PORT || 28015,
+  db: 'acuitydb'
 }

--- a/server/config.js
+++ b/server/config.js
@@ -1,0 +1,4 @@
+exports.db = {
+  host: process.env.TITS_DB_URL || 'localhost'.
+  port: process.env.TITS_DB_PORT || 28015
+}

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,5 @@
+// require babel require hook
+require('babel-core/register')
+
+// require server code
+require('./src')

--- a/server/package.json
+++ b/server/package.json
@@ -48,6 +48,7 @@
     "koa-morgan": "^1.0.1",
     "koa-route": "^3.2.0",
     "lodash": "^4.16.2",
+    "thinky": "^2.3.6",
     "winston": "^2.2.0"
   },
   "babel": {

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "Acuity REST Backend",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "mocha --require test/helpers test/**/*.spec.js --compilers js:babel-register -R dot --timeout 5000",
     "start": "node index",
     "db:start": "node util/db/start",
     "db:stop": "docker stop acuitydb",
@@ -25,11 +25,13 @@
   "author": "Elias Jørgensen <elias@entake.dk> (http://eliasjorgensen.me)",
   "license": "MIT",
   "devDependencies": {
+    "app-module-path": "^2.0.0",
     "babel-cli": "^6.14.0",
     "babel-core": "^6.14.0",
     "babel-eslint": "^7.0.0",
-    "babel-preset-es2015-node": "^6.1.1",
-    "babel-preset-stage-0": "^6.5.0",
+    "babel-plugin-transform-runtime": "^6.15.0",
+    "babel-preset-es2015-node6": "^0.3.0",
+    "babel-preset-stage-1": "^6.16.0",
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "eslint-config-standard": "^6.1.0",
@@ -37,17 +39,24 @@
     "eslint-plugin-promise": "^2.0.1",
     "eslint-plugin-standard": "^2.0.0",
     "koa-logger": "^2.0.0",
-    "mocha": "^3.1.0"
+    "mocha": "^3.1.0",
+    "supertest": "^2.0.0"
   },
   "dependencies": {
+    "bristol": "^0.3.3",
     "kcors": "^2.2.0",
     "koa": "^2.0.0",
-    "koa-route": "^3.2.0"
+    "koa-route": "^3.2.0",
+    "lodash": "^4.16.2",
+    "palin": "^2.1.0"
   },
   "babel": {
     "presets": [
-      "es2015-node",
-      "stage-0"
+      "es2015-node6",
+      "stage-1"
+    ],
+    "plugins": [
+      "transform-runtime"
     ]
   },
   "eslintConfig": {

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "test": "mocha --require test/helpers test/**/*.spec.js --compilers js:babel-register --timeout 5000",
     "start": "node index",
-    "db:start": "node util/db/start",
+    "db:create": "node util/db/start",
+    "db:start": "docker start acuitydb",
     "db:stop": "docker stop acuitydb",
     "db:rm": "docker rm acuitydb"
   },
@@ -36,7 +37,7 @@
     "chai": "^3.5.0",
     "eslint": "^3.6.1",
     "eslint-config-standard": "^6.1.0",
-    "eslint-plugin-import": "^1.16.0",
+    "eslint-plugin-import": "^2.0.0",
     "eslint-plugin-promise": "^2.0.1",
     "eslint-plugin-standard": "^2.0.0",
     "mocha": "^3.1.0",

--- a/server/package.json
+++ b/server/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "tiss-backend",
+  "name": "acuity-backend",
   "version": "0.1.0",
-  "description": "TISS REST Backend",
+  "description": "Acuity REST Backend",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "node index",
     "db:start": "node util/db/start",
-    "db:stop": "docker stop tissdb",
-    "db:rm": "docker rm tissdb"
+    "db:stop": "docker stop acuitydb",
+    "db:rm": "docker rm acuitydb"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Entake/tiss/"
+    "url": "https://github.com/Entake/acuity/"
   },
   "keywords": [
     "REST",

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "Acuity REST Backend",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --require test/helpers test/**/*.spec.js --compilers js:babel-register -R spec --ui bdd --timeout 5000",
+    "test": "mocha --require test/helpers test/**/*.spec.js --compilers js:babel-register --timeout 5000",
     "start": "node index",
     "db:start": "node util/db/start",
     "db:stop": "docker stop acuitydb",
@@ -29,6 +29,7 @@
     "babel-cli": "^6.14.0",
     "babel-core": "^6.14.0",
     "babel-eslint": "^7.0.0",
+    "babel-plugin-transform-do-expressions": "^6.8.0",
     "babel-plugin-transform-runtime": "^6.15.0",
     "babel-preset-es2015-node6": "^0.3.0",
     "babel-preset-stage-1": "^6.16.0",
@@ -38,17 +39,16 @@
     "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-promise": "^2.0.1",
     "eslint-plugin-standard": "^2.0.0",
-    "koa-logger": "^2.0.0",
     "mocha": "^3.1.0",
     "supertest": "^2.0.0"
   },
   "dependencies": {
-    "bristol": "^0.3.3",
     "kcors": "^2.2.0",
     "koa": "^2.0.0",
+    "koa-morgan": "^1.0.1",
     "koa-route": "^3.2.0",
     "lodash": "^4.16.2",
-    "palin": "^2.1.0"
+    "winston": "^2.2.0"
   },
   "babel": {
     "presets": [
@@ -56,7 +56,8 @@
       "stage-1"
     ],
     "plugins": [
-      "transform-runtime"
+      "transform-runtime",
+      "transform-do-expressions"
     ]
   },
   "eslintConfig": {

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "description": "Acuity REST Backend",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --require test/helpers test/**/*.spec.js --compilers js:babel-register -R dot --timeout 5000",
+    "test": "mocha --require test/helpers test/**/*.spec.js --compilers js:babel-register -R spec --ui bdd --timeout 5000",
     "start": "node index",
     "db:start": "node util/db/start",
     "db:stop": "docker stop acuitydb",

--- a/server/package.json
+++ b/server/package.json
@@ -36,6 +36,7 @@
     "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-promise": "^2.0.1",
     "eslint-plugin-standard": "^2.0.0",
+    "koa-logger": "^2.0.0",
     "mocha": "^3.1.0"
   },
   "dependencies": {

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "tits-backend",
+  "version": "0.1.0",
+  "description": "TIT.s REST Backend",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Entake/tit.s/"
+  },
+  "keywords": [
+    "REST",
+    "JavaScript",
+    "thatimagetaggingsite",
+    "Node",
+    "RethinkDB",
+    "GoogleVision"
+  ],
+  "author": "Elias Jørgensen <elias@entake.dk> (http://eliasjorgensen.me)",
+  "license": "MIT",
+  "devDependencies": {
+    "babel-cli": "^6.14.0",
+    "babel-core": "^6.14.0",
+    "babel-eslint": "^7.0.0",
+    "babel-preset-es2015-node": "^6.1.1",
+    "babel-preset-stage-0": "^6.5.0",
+    "chai": "^3.5.0",
+    "eslint": "^3.6.1",
+    "eslint-config-standard": "^6.1.0",
+    "eslint-plugin-import": "^1.16.0",
+    "eslint-plugin-promise": "^2.0.1",
+    "eslint-plugin-standard": "^2.0.0",
+    "mocha": "^3.1.0"
+  },
+  "dependencies": {
+    "kcors": "^2.2.0",
+    "koa": "^2.0.0",
+    "koa-route": "^3.2.0"
+  },
+  "babel": {
+    "presets": [
+      "es2015-node",
+      "stage-0"
+    ]
+  },
+  "eslintConfig": {
+    "parser": "babel-eslint",
+    "extends": [
+      "standard"
+    ],
+    "rules": {
+      "no-multi-spaces": [
+        1,
+        {
+          "exceptions": {
+            "VariableDeclarator": true,
+            "ImportDeclaration": true
+          }
+        }
+      ]
+    }
+  }
+}

--- a/server/package.json
+++ b/server/package.json
@@ -45,8 +45,9 @@
   "dependencies": {
     "kcors": "^2.2.0",
     "koa": "^2.0.0",
+    "koa-bodyparser": "^3.2.0",
     "koa-morgan": "^1.0.1",
-    "koa-route": "^3.2.0",
+    "koa-router": "^7.0.1",
     "lodash": "^4.16.2",
     "thinky": "^2.3.6",
     "winston": "^2.2.0"

--- a/server/package.json
+++ b/server/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "tits-backend",
+  "name": "tiss-backend",
   "version": "0.1.0",
-  "description": "TIT.s REST Backend",
+  "description": "TISS REST Backend",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Entake/tit.s/"
+    "url": "https://github.com/Entake/tiss/"
   },
   "keywords": [
     "REST",

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,10 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node index.js"
+    "start": "node index",
+    "db:start": "node util/db/start",
+    "db:stop": "docker stop tissdb",
+    "db:rm": "docker rm tissdb"
   },
   "repository": {
     "type": "git",

--- a/server/src/db/index.js
+++ b/server/src/db/index.js
@@ -1,0 +1,1 @@
+export { thinky, r } from './thinky'

--- a/server/src/db/index.js
+++ b/server/src/db/index.js
@@ -1,1 +1,2 @@
 export { thinky, r } from './thinky'
+export { User } from './user'

--- a/server/src/db/thinky.js
+++ b/server/src/db/thinky.js
@@ -1,0 +1,11 @@
+// Libraries
+import initThinky from 'thinky'
+
+// DB config
+import { db as dbConfig } from '../../config'
+
+// Init thinky
+const thinky = initThinky(dbConfig)
+const { r } = thinky
+
+export { thinky, r }

--- a/server/src/db/user.js
+++ b/server/src/db/user.js
@@ -1,0 +1,9 @@
+// Thinky instance
+import { thinky } from './thinky'
+
+export const User = thinky.createModel('User', {
+  email: thinky.type.string().required(),
+  login: thinky.type.string().required(),
+  password: thinky.type.string().required(),
+  registrationDate: thinky.type.date().default(thinky.r.now())
+})

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -13,5 +13,12 @@ thinky.dbReady().then(() => {
     app.listen(PORT, () => {
       logger.info(`🌍  acuity-backend is listening at http://localhost:${PORT}`)
     })
+
+    // catch errors
+  }).catch(e => {
+    logger.error(e)
+    process.exit()
   })
+}).catch(e => {
+  logger.error(e)
 })

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,10 +1,17 @@
+// Our modules
 import createServer from './server'
+import { logger } from './util'
+import { thinky } from './db'
 
 const PORT = 8080
 
-// Start server
-createServer().then(app => {
-  app.listen(PORT, () => {
-    console.log(`🌍  acuity-backend is listening at http://localhost:${PORT}`)
+// Wait for DB to initialize
+thinky.dbReady().then(() => {
+  logger.info('Database ready, starting server...')
+  // Start server
+  createServer().then(app => {
+    app.listen(PORT, () => {
+      logger.info(`🌍  acuity-backend is listening at http://localhost:${PORT}`)
+    })
   })
 })

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,6 +1,10 @@
-import app from './server'
+import createServer from './server'
+
+const PORT = 8080
 
 // Start server
-app.listen(8080, () => {
-  console.log('🌍  acuity-backend is listening at http://localhost:8080')
+createServer().then(app => {
+  app.listen(PORT, () => {
+    console.log(`🌍  acuity-backend is listening at http://localhost:${PORT}`)
+  })
 })

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -19,5 +19,5 @@ app.use(Route.get('/', ctx => {
 
 // Start server
 app.listen(PORT, () => {
-  console.log('🌍  tiss-backend is listening at http://localhost:8080')
+  console.log('🌍  acuity-backend is listening at http://localhost:8080')
 })

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -17,5 +17,5 @@ app.use(Route.get('/', ctx => {
 
 // Start server
 app.listen(PORT, () => {
-  console.log('🌍  tits-backend is listening at http://localhost:8080')
+  console.log('🌍  tiss-backend is listening at http://localhost:8080')
 })

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,6 +1,7 @@
 // Libraries
 import Koa from 'koa'
 import Route from 'koa-route'
+import Logger from 'koa-logger'
 import Cors from 'kcors'
 
 // Setup app
@@ -8,6 +9,7 @@ const app = new Koa()
 const PORT = 8080
 
 // Setup middlewares
+app.use(Logger())
 app.use(Cors())
 
 // Test request

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,23 +1,6 @@
-// Libraries
-import Koa from 'koa'
-import Route from 'koa-route'
-import Logger from 'koa-logger'
-import Cors from 'kcors'
-
-// Setup app
-const app = new Koa()
-const PORT = 8080
-
-// Setup middlewares
-app.use(Logger())
-app.use(Cors())
-
-// Test request
-app.use(Route.get('/', ctx => {
-  ctx.body = 'I\'m mr. Meeseeks!'
-}))
+import app from './server'
 
 // Start server
-app.listen(PORT, () => {
+app.listen(8080, () => {
   console.log('🌍  acuity-backend is listening at http://localhost:8080')
 })

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -22,3 +22,7 @@ thinky.dbReady().then(() => {
 }).catch(e => {
   logger.error(e)
 })
+
+// output all uncaught exceptions
+process.on('uncaughtException', err => logger.error('uncaught exception:', err))
+process.on('unhandledRejection', err => logger.error('unhandled rejection:', err))

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,0 +1,21 @@
+// Libraries
+import Koa from 'koa'
+import Route from 'koa-route'
+import Cors from 'kcors'
+
+// Setup app
+const app = new Koa()
+const PORT = 8080
+
+// Setup middlewares
+app.use(Cors())
+
+// Test request
+app.use(Route.get('/', ctx => {
+  ctx.body = 'I\'m mr. Meeseeks!'
+}))
+
+// Start server
+app.listen(PORT, () => {
+  console.log('🌍  tits-backend is listening at http://localhost:8080')
+})

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,0 +1,17 @@
+// Libraries
+import Koa from 'koa'
+import Route from 'koa-route'
+import Logger from 'koa-logger'
+import Cors from 'kcors'
+
+// Setup app
+const app = new Koa()
+
+// Setup middlewares
+app.use(Logger())
+app.use(Cors())
+
+// Test request
+app.use(Route.get('/', ctx => {
+  ctx.body = 'I\'m mr. Meeseeks!'
+}))

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,15 +1,18 @@
 // Libraries
 import Koa from 'koa'
 import Route from 'koa-route'
-import Logger from 'koa-logger'
+import Morgan from 'koa-morgan'
 import Cors from 'kcors'
+
+// Our modules
+import { logger } from './util'
 
 export default async function Server () {
   // Setup app
   const app = new Koa()
 
   // Setup middlewares
-  app.use(Logger())
+  app.use(Morgan(process.env.NODE_ENV ? 'combined' : 'dev', { stream: logger.stream }))
   app.use(Cors())
 
   // Test request

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -1,6 +1,7 @@
 // Libraries
 import Koa from 'koa'
-import Route from 'koa-route'
+import Router from 'koa-router'
+import Parser from 'koa-bodyparser'
 import Morgan from 'koa-morgan'
 import Cors from 'kcors'
 
@@ -10,6 +11,7 @@ import { logger } from './util'
 export default async function Server () {
   // Setup app
   const app = new Koa()
+  const router = new Router()
 
   // Setup logging
   app.use(Morgan(
@@ -17,13 +19,16 @@ export default async function Server () {
     { stream: logger.stream }
   ))
 
+  // Setup routes
+  router.get('/', ctx => {
+    ctx.body = 'I\'m mr. Meeseeks!'
+  })
+
   // Setup middlewares
   app.use(Cors())
-
-  // Test request
-  app.use(Route.get('/', ctx => {
-    ctx.body = 'I\'m mr. Meeseeks!'
-  }))
+  app.use(Parser())
+  app.use(router.routes())
+  app.use(router.allowedMethods())
 
   return app
 }

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -4,14 +4,18 @@ import Route from 'koa-route'
 import Logger from 'koa-logger'
 import Cors from 'kcors'
 
-// Setup app
-const app = new Koa()
+export default async function Server () {
+  // Setup app
+  const app = new Koa()
 
-// Setup middlewares
-app.use(Logger())
-app.use(Cors())
+  // Setup middlewares
+  app.use(Logger())
+  app.use(Cors())
 
-// Test request
-app.use(Route.get('/', ctx => {
-  ctx.body = 'I\'m mr. Meeseeks!'
-}))
+  // Test request
+  app.use(Route.get('/', ctx => {
+    ctx.body = 'I\'m mr. Meeseeks!'
+  }))
+
+  return app
+}

--- a/server/src/server.js
+++ b/server/src/server.js
@@ -11,8 +11,13 @@ export default async function Server () {
   // Setup app
   const app = new Koa()
 
+  // Setup logging
+  app.use(Morgan(
+    process.env.NODE_ENV ? 'combined' : 'dev',
+    { stream: logger.stream }
+  ))
+
   // Setup middlewares
-  app.use(Morgan(process.env.NODE_ENV ? 'combined' : 'dev', { stream: logger.stream }))
   app.use(Cors())
 
   // Test request

--- a/server/src/util/index.js
+++ b/server/src/util/index.js
@@ -1,0 +1,1 @@
+export { logger } from './logger'

--- a/server/src/util/logger.js
+++ b/server/src/util/logger.js
@@ -1,0 +1,26 @@
+import winston from 'winston'
+
+export const logger = new winston.Logger({
+  transports: [
+    new winston.transports.Console({
+      level: do {
+        if (process.env.NODE_ENV === 'testing') {
+          'error'
+        } else if (process.env.NODE_ENV === 'production') {
+          'info'
+        } else {
+          'debug'
+        }
+      },
+      colorize: true,
+      timestamp: true,
+      prettyPrint: true,
+      label: 'acuity-backend'
+    })
+  ]
+})
+
+// create stream for morgan
+logger.stream = {
+  write: message => logger.info(message)
+}

--- a/server/test/.eslintrc
+++ b/server/test/.eslintrc
@@ -1,0 +1,14 @@
+{
+  "rules": {
+    "no-unused-expressions": 0
+  },
+  "globals": {
+    "it": true,
+    "describe": true,
+    "expect": true,
+    "before": true,
+    "beforeEach": true,
+    "after": true,
+    "afterEach": true
+  }
+}

--- a/server/test/api/server.spec.js
+++ b/server/test/api/server.spec.js
@@ -1,0 +1,17 @@
+import createServer from '../helpers/createServer'
+
+describe('Acuity API', () => {
+  let request
+  before(async () => {
+    request = await createServer()
+  })
+
+  describe('GET /', () => {
+    it('presses the button on the sacred box', async () => {
+      await request.get('/')
+        .expect(200, {
+          data: 'I\'m mr. Meeseeks!'
+        })
+    })
+  })
+})

--- a/server/test/api/server.spec.js
+++ b/server/test/api/server.spec.js
@@ -7,10 +7,27 @@ describe('Acuity API', () => {
   })
 
   describe('GET /', () => {
-    it('presses the button on the sacred box', async () => {
+    it('Returns R&M reference', async () => {
       await request.get('/')
-        .expect(200, {
-          data: 'I\'m mr. Meeseeks!'
+        .expect(200)
+        .expect('Content-Type', 'text/plain; charset=utf-8')
+        .expect((err, res) => {
+          if (err) return err
+
+          expect(res.text).to.equal('I\'m mr. Meeseeks!')
+        })
+    })
+  })
+
+  describe('GET /RandomURL', () => {
+    it('Returns 404 on nonexistant URL', async () => {
+      await request.get('/RandomURL')
+        .expect(404)
+        .expect('Content-Type', 'text/plain; charset=utf-8')
+        .expect((err, res) => {
+          if (err) return err
+
+          expect(res.text).to.equal('Not found')
         })
     })
   })

--- a/server/test/helpers/createServer.js
+++ b/server/test/helpers/createServer.js
@@ -1,0 +1,36 @@
+import agent from 'supertest'
+import http from 'http'
+import memoize from 'lodash/memoize'
+
+import createServer from 'server.js'
+
+let _app, _server
+const createTestServer = memoize(async () => {
+  const app = _app = await createServer()
+  _server = http.createServer(
+    app.callback()
+  )
+
+  await new Promise(
+    (resolve, reject) => _server.listen(0, (err) => err ? reject(err) : resolve())
+  )
+
+  const req = agent(
+    _server
+  )
+
+  req.app = app
+  return req
+})
+
+before(() => {
+  return createTestServer()
+})
+
+after((done) => {
+  if (_app) {
+    _server.close(done)
+  }
+})
+
+export default createTestServer

--- a/server/test/helpers/index.js
+++ b/server/test/helpers/index.js
@@ -2,6 +2,8 @@ import chai from 'chai'
 import appModulePath from 'app-module-path'
 import path from 'path'
 
+// Usage of process.env is workaround for issues with setting env vars in windows
+process.env.NODE_ENV = 'testing'
 // Basically makes us able to "import stuff from 'some/source/folder'"
 appModulePath.addPath(path.join(__dirname, '/../../src'))
 chai.config.includeStack = true

--- a/server/test/helpers/index.js
+++ b/server/test/helpers/index.js
@@ -1,0 +1,12 @@
+import chai from 'chai'
+import appModulePath from 'app-module-path'
+import path from 'path'
+
+// Basically makes us able to "import stuff from 'some/source/folder'"
+appModulePath.addPath(path.join(__dirname, '/../../src'))
+chai.config.includeStack = true
+chai.should()
+global.expect = chai.expect
+global.AssertionError = chai.AssertionError
+global.Assertion = chai.Assertion
+global.assert = chai.assert

--- a/server/util/db/start.js
+++ b/server/util/db/start.js
@@ -1,0 +1,34 @@
+/* eslint no-console: 0 */
+
+// Libraries
+const Exec = require('child_process').exec
+const Path = require('path')
+
+// Dir to store the data in
+const dbPath = Path.join(__dirname, '..', '..', 'db')
+
+// Docker run command
+const cmd = `docker run -d -p 28015:28015 -p 8090:8080 -v ${dbPath}:/data --name tissdb rethinkdb`
+
+// Execute command
+const start = Exec(cmd)
+
+// Remember if docker is installing image
+let dbImage = false
+
+// Runs when command writes to stdout
+start.stdout.on('data', (data) => {
+  if (data) {
+    console.log('Sucessfully created tissdb\n')
+  }
+})
+
+// Runs when command writes to stderr
+start.stderr.on('data', (data) => {
+  if (data === "Unable to find image 'rethinkdb:latest' locally\n" || dbImage) {
+    console.log(data)
+    dbImage = true
+  } else {
+    console.log('Error while creating tissdb:', data)
+  }
+})

--- a/server/util/db/start.js
+++ b/server/util/db/start.js
@@ -8,7 +8,7 @@ const Path = require('path')
 const dbPath = Path.join(__dirname, '..', '..', 'db')
 
 // Docker run command
-const cmd = `docker run -d -p 28015:28015 -p 8090:8080 -v ${dbPath}:/data --name tissdb rethinkdb`
+const cmd = `docker run -d -p 28015:28015 -p 8090:8080 -v ${dbPath}:/data --name acuitydb rethinkdb`
 
 // Execute command
 const start = Exec(cmd)
@@ -19,7 +19,7 @@ let dbImage = false
 // Runs when command writes to stdout
 start.stdout.on('data', (data) => {
   if (data) {
-    console.log('Sucessfully created tissdb\n')
+    console.log('Sucessfully created acuitydb\n')
   }
 })
 
@@ -29,6 +29,6 @@ start.stderr.on('data', (data) => {
     console.log(data)
     dbImage = true
   } else {
-    console.log('Error while creating tissdb:', data)
+    console.log('Error while creating acuitydb:', data)
   }
 })


### PR DESCRIPTION
# First part of issue #2 

This initial backend setup contains the following:
* Backend backbone, with CORS/BodyParsing/Routing support, using Koa
* ES7 support, using Babel, with the es2015-node6 and stage-1 presets
* Linting, using ESLint and the [Standard](http://standardjs.com/) styleguide
* NPM scripts, for creating/starting/stopping/removing a RethinkDB Docker container
* Unit test setup, using Mocha/Chai/Supertest
* Initial DB setup, with RethinkDB and the Thinky ORM
* Logging, manually and automatic middleware logging, using Morgan/Winston

Missing:
* README text/badges

@Entake/developers @rune3132 